### PR TITLE
Fix broken ng-click

### DIFF
--- a/src/bootstrap/choices.tpl.html
+++ b/src/bootstrap/choices.tpl.html
@@ -6,7 +6,7 @@
     <div ng-show="$select.isGrouped" class="ui-select-choices-group-label dropdown-header" ng-bind="$group.name"></div>
     <div id="ui-select-choices-row-{{ $select.generatedId }}-{{$index}}" class="ui-select-choices-row"
     ng-class="{active: $select.isActive(this), disabled: $select.isDisabled(this)}" role="option">
-      <a ng-click="$event.preventDefault()" class="ui-select-choices-row-inner"></a>
+      <a href="" class="ui-select-choices-row-inner"></a>
     </div>
   </li>
 </ul>


### PR DESCRIPTION
https://github.com/angular-ui/ui-select/commit/4467b8238866f85003f8815f44a7ca8563222043 made the cursor not change into a hand when hovering over an item because the a doesn't have an href.
This pull request removes the ng-click with prevent default because an empty href in angular does exactly the same. See: https://docs.angularjs.org/api/ng/directive/a

Here is an example of the current master version: http://plnkr.co/edit/O2tbRRFOC0IDwHI363cM?p=preview
And here is an example with this change: http://plnkr.co/edit/MXW3abVF9l0fzYElYDv1?p=preview
